### PR TITLE
Add pausable mode to whisper-stream

### DIFF
--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include <vector>
 #include <atomic>
+#include <iostream> 
 
 // command-line parameters
 struct whisper_params {
@@ -65,7 +66,7 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
         else if (arg == "-mt"   || arg == "--max-tokens")    { params.max_tokens    = std::stoi(argv[++i]); }
         else if (arg == "-ac"   || arg == "--audio-ctx")     { params.audio_ctx     = std::stoi(argv[++i]); }
         else if (arg == "-bs"   || arg == "--beam-size")     { params.beam_size     = std::stoi(argv[++i]); }
-        else if (arg == "-tn"   || arg == "--top")          { params.top_n         = std::stoi(argv[++i]); params.top_n_set = true; }
+        else if (arg == "-tn"   || arg == "--top")           { params.top_n         = std::stoi(argv[++i]); params.top_n_set = true; }
         else if (arg == "-vth"  || arg == "--vad-thold")     { params.vad_thold     = std::stof(argv[++i]); }
         else if (arg == "-fth"  || arg == "--freq-thold")    { params.freq_thold    = std::stof(argv[++i]); }
         else if (arg == "-tr"   || arg == "--translate")     { params.translate     = true; }
@@ -79,7 +80,7 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
         else if (arg == "-sa"   || arg == "--save-audio")    { params.save_audio    = true; }
         else if (arg == "-ng"   || arg == "--no-gpu")        { params.use_gpu       = false; }
         else if (arg == "-fa"   || arg == "--flash-attn")    { params.flash_attn    = true; }
-        else if (                 arg == "--pausable")       { params.pausable      = true; }
+        else if (arg == "-p"    || arg == "--pausable")      { params.pausable      = true; }
 
         else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
@@ -119,7 +120,7 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "  -sa,      --save-audio    [%-7s] save the recorded audio to a file\n",              params.save_audio ? "true" : "false");
     fprintf(stderr, "  -ng,      --no-gpu        [%-7s] disable GPU inference\n",                          params.use_gpu ? "false" : "true");
     fprintf(stderr, "  -fa,      --flash-attn    [%-7s] flash attention during inference\n",               params.flash_attn ? "true" : "false");
-    fprintf(stderr, "            --pausable      [%-7s] allow stdin commands [PAUSE]/[RESUME]\n", params.pausable ? "true" : "false");
+    fprintf(stderr, "            --pausable      [%-7s] allow stdin commands p,n (PAUSE)/(RESUME)\n",      params.pausable ? "true" : "false");
     fprintf(stderr, "\n");
 }
 
@@ -249,12 +250,13 @@ int main(int argc, char ** argv) {
                 if (!std::getline(std::cin, line)) {
                     break;
                 }
-                if (line == "[PAUSE]") {
+
+                if (line == "p") {
                     control_state = 1;
-                } else if (line == "[RESUME]") {
+                } else if (line == "r") {
                     control_state = 2;
                 } else {
-                    fprintf(stderr, "Only [PAUSE], [RESUME] accepted\n");
+                    fprintf(stderr, "[ERROR] Only 'p' (pause), 'r' (resume) accepted]\n");
                 }
             }
         });
@@ -278,8 +280,15 @@ int main(int argc, char ** argv) {
         if (params.pausable) {
             int st = control_state.exchange(0);
             if (st == 1 && !is_paused) {
+                //audio.clear();
                 audio.pause();
-                audio.clear();
+
+                params.no_context = true;
+
+                pcmf32.clear();
+                pcmf32_new.clear();
+                pcmf32_old.clear();
+                prompt_tokens.clear();
                 is_paused = true;
             } else if (st == 2 && is_paused) {
                 audio.resume();

--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <atomic>
 
 // command-line parameters
 struct whisper_params {
@@ -39,6 +40,7 @@ struct whisper_params {
     bool save_audio    = false; // save audio to wav file
     bool use_gpu       = true;
     bool flash_attn    = false;
+    bool pausable      = false;
 
     std::string language  = "en";
     std::string model     = "models/ggml-base.en.bin";
@@ -77,6 +79,7 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
         else if (arg == "-sa"   || arg == "--save-audio")    { params.save_audio    = true; }
         else if (arg == "-ng"   || arg == "--no-gpu")        { params.use_gpu       = false; }
         else if (arg == "-fa"   || arg == "--flash-attn")    { params.flash_attn    = true; }
+        else if (                 arg == "--pausable")       { params.pausable      = true; }
 
         else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
@@ -116,6 +119,7 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "  -sa,      --save-audio    [%-7s] save the recorded audio to a file\n",              params.save_audio ? "true" : "false");
     fprintf(stderr, "  -ng,      --no-gpu        [%-7s] disable GPU inference\n",                          params.use_gpu ? "false" : "true");
     fprintf(stderr, "  -fa,      --flash-attn    [%-7s] flash attention during inference\n",               params.flash_attn ? "true" : "false");
+    fprintf(stderr, "            --pausable      [%-7s] allow stdin commands [PAUSE]/[RESUME]\n", params.pausable ? "true" : "false");
     fprintf(stderr, "\n");
 }
 
@@ -210,7 +214,9 @@ int main(int argc, char ** argv) {
 
     int n_iter = 0;
 
-    bool is_running = true;
+    std::atomic_bool is_running(true);
+    std::atomic_bool is_paused(false);
+    std::atomic_int  control_state(0); // 1 - pause, 2 - resume
 
     std::ofstream fout;
     if (params.fname_out.length() > 0) {
@@ -235,6 +241,25 @@ int main(int argc, char ** argv) {
     printf("[Start speaking]\n");
     fflush(stdout);
 
+    std::thread control_thread;
+    if (params.pausable) {
+        control_thread = std::thread([&]() {
+            std::string line;
+            while (is_running) {
+                if (!std::getline(std::cin, line)) {
+                    break;
+                }
+                if (line == "[PAUSE]") {
+                    control_state = 1;
+                } else if (line == "[RESUME]") {
+                    control_state = 2;
+                } else {
+                    fprintf(stderr, "Only [PAUSE], [RESUME] accepted\n");
+                }
+            }
+        });
+    }
+
     auto t_last  = std::chrono::high_resolution_clock::now();
     const auto t_start = t_last;
 
@@ -248,6 +273,24 @@ int main(int argc, char ** argv) {
 
         if (!is_running) {
             break;
+        }
+
+        if (params.pausable) {
+            int st = control_state.exchange(0);
+            if (st == 1 && !is_paused) {
+                audio.pause();
+                audio.clear();
+                is_paused = true;
+            } else if (st == 2 && is_paused) {
+                audio.resume();
+                is_paused = false;
+                t_last = std::chrono::high_resolution_clock::now();
+            }
+
+            if (is_paused) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                continue;
+            }
         }
 
         // process new audio
@@ -446,6 +489,11 @@ int main(int argc, char ** argv) {
     }
 
     audio.pause();
+
+    is_running = false;
+    if (params.pausable && control_thread.joinable()) {
+        control_thread.join();
+    }
 
     whisper_print_timings(ctx);
     whisper_free(ctx);


### PR DESCRIPTION
## Summary
- add `--pausable` option to whisper-stream
- allow pause/resume via stdin commands

## Testing
- `g++ -std=c++11 -c examples/stream/stream.cpp -I./ -I./include -Iexamples -DWHISPER_CPP` *(fails: SDL.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684eca283edc832eac2205da47b40dc8